### PR TITLE
Adjust bash/fish scripts so that they very closely resemble each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Add following lines to `$HOME/.config/fish/config.fish`:
 # Base16 Shell
 if status --is-interactive
   set BASE16_SHELL_PATH "$HOME/.config/base16-shell"
-  source "$BASE16_SHELL_PATH/profile_helper.fish"
+  if test -s "$BASE16_SHELL_PATH"
+    source "$BASE16_SHELL_PATH/profile_helper.fish"
+  end
 end
 ```
 

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -1,59 +1,110 @@
 #!/usr/bin/env fish
 
-# [what] provides aliases for base16 themes and sets
-# $HOME/.config/base16-project/base16_shell_theme
-#
-# [usage] can be added to $HOME/.config/fish/config.fish like so:
-#
-# if status --is-interactive
-#    source $HOME/.config/base16-shell/profile_helper.fish
-# end
-#
-# TODO: maybe port to $HOME/.config/fish/functions ?
+# ----------------------------------------------------------------------
+# Setup variables and env
+# ----------------------------------------------------------------------
 
 set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
-set BASE16_SHELL_COLORSCHEME_PATH "$BASE16_CONFIG_PATH/base16_shell_theme"
+set BASE16_SHELL_COLORSCHEME_PATH \
+  "$BASE16_CONFIG_PATH/base16_shell_theme"
 set BASE16_SHELL_TMUXCONF_PATH "$BASE16_CONFIG_PATH/tmux.base16.conf"
 set BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
 
-if not test -d "$BASE16_CONFIG_PATH"
-  mkdir -p "$BASE16_CONFIG_PATH"
-end
-
+# Allow users to optionally configure their base16-shell path and set
+# the value if one doesn't exist
 if test -z $BASE16_SHELL_PATH
   set -g BASE16_SHELL_PATH (cd (dirname (status -f)); and pwd)
 end
 
-# Load the active theme
-if test -e $BASE16_SHELL_COLORSCHEME_PATH
-  sh $BASE16_SHELL_COLORSCHEME_PATH
+# Allow users to optionally configure their tmux plugin path and set
+# the value if one doesn't exist
+if test -z $BASE16_TMUX_PLUGIN_PATH
+  set BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
 end
 
-if test -n "$BASE16_THEME_DEFAULT"; and not test -e $BASE16_SHELL_COLORSCHEME_PATH
-  ln -s "$BASE16_SHELL_PATH/scripts/base16-$BASE16_THEME_DEFAULT.sh" \
-    $BASE16_SHELL_COLORSCHEME_PATH
+# Create the config path if the path doesn't currently exist
+if not test -d "$BASE16_CONFIG_PATH"
+  mkdir -p "$BASE16_CONFIG_PATH"
 end
 
-# Set base16-* aliases
-for SCRIPT in $BASE16_SHELL_PATH/scripts/*.sh
-  set THEME (basename $SCRIPT .sh)
-  function $THEME -V SCRIPT -V THEME
-    set partial_theme_name (string replace -a 'base16-' '' $THEME) # eg: ocean
-    sh $SCRIPT
-    ln -sf $SCRIPT $BASE16_SHELL_COLORSCHEME_PATH
-    # If base16-tmux is used, provide a file to source when the theme changes
-    if test -e "$BASE16_TMUX_PLUGIN_PATH"
-      echo "set -g @colors-base16 '$partial_theme_name'" > "$BASE16_SHELL_TMUXCONF_PATH"
-    end
+# ----------------------------------------------------------------------
+# Functions
+# ----------------------------------------------------------------------
 
-    if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
-      for hook in $BASE16_SHELL_HOOKS/*
-        test -f "$hook"; and test -x "$hook"; and "$hook"
-      end
-    end
+function set_theme
+  set theme_name $argv[1]
+
+  if not test -e $BASE16_CONFIG_PATH
+    echo "\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this script \
+      and then try again"
+    return 2
   end
+
+  if test -z $theme_name
+    echo "Provide a theme name to set_theme or ensure \
+      \$BASE16_THEME_DEFAULT is set"
+    return 1
+  end
+
+  # Symlink and source
+  ln -fs \
+    "$BASE16_SHELL_PATH/scripts/base16-$theme_name.sh" \
+    "$BASE16_SHELL_COLORSCHEME_PATH"
+  if not test -e "$BASE16_SHELL_COLORSCHEME_PATH"
+    echo "Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH \
+    and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    return 2
+  end
+
+  # Source newly symlinked file
+  if test -f "$BASE16_SHELL_COLORSCHEME_PATH"
+    sh $BASE16_SHELL_COLORSCHEME_PATH
+
+    # Env variables aren't globally set when bash shell is sourced
+    set -g BASE16_THEME "$theme_name"
+  end
+
+  # If base16-tmux is used, provide a file for base16-tmux to source
+  if test -e "$BASE16_TMUX_PLUGIN_PATH"
+    echo "set -g @colors-base16 '$theme_name'" > \
+      "$BASE16_SHELL_TMUXCONF_PATH"
+  end
+
+  if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
+    for hook in $BASE16_SHELL_HOOKS/*
+      test -f "$hook"; and test -x "$hook"; and "$hook"
+    end
+   end
 end
 
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
+
+# Reload the $BASE16_SHELL_COLORSCHEME_PATH when the shell is reset
 alias reset "command reset \
   && [ -f $BASE16_SHELL_COLORSCHEME_PATH ] \
   && sh $BASE16_SHELL_COLORSCHEME_PATH"
+
+# Set base16-* aliases
+for script_path in $BASE16_SHELL_PATH/scripts/*.sh
+  set function_name (basename $script_path .sh)
+  set theme_name (string replace -a 'base16-' '' $function_name) 
+
+  alias $function_name="set_theme \"$theme_name\""
+end
+
+# Load the active theme
+if test -e "$BASE16_SHELL_COLORSCHEME_PATH"
+  # Get the active theme name from the export variable in the script
+  set current_theme_name \
+    $(grep -P 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
+  set current_theme_name \
+    $(string replace -r 'export BASE16_THEME=' '' $current_theme_name)
+  set_theme "$current_theme_name"
+# If a colorscheme file doesn't exist and BASE16_THEME_DEFAULT is set,
+# then create the colorscheme file based on the BASE16_THEME_DEFAULT
+# scheme name
+else if test -n "$BASE16_THEME_DEFAULT"
+  set_theme "$BASE16_THEME_DEFAULT"
+end

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
+# ----------------------------------------------------------------------
+# Setup config variables and env
+# ----------------------------------------------------------------------
+
 BASE16_CONFIG_PATH="$HOME/.config/base16-project"
 BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
 BASE16_SHELL_TMUXCONF_PATH="$BASE16_CONFIG_PATH/tmux.base16.conf"
 BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
 
-if [ ! -d "$BASE16_CONFIG_PATH" ]; then
-  mkdir -p "$BASE16_CONFIG_PATH"
-fi
-
+# Allow users to optionally configure their base16-shell path and set
+# the value if one doesn't exist
 if [ -z "$BASE16_SHELL_PATH" ]; then
   if [ -n "$BASH_VERSION" ]; then
     script_path=${BASH_SOURCE[0]}
@@ -19,17 +21,53 @@ if [ -z "$BASE16_SHELL_PATH" ]; then
   BASE16_SHELL_PATH=${script_path%/*}
 fi
 
-_base16()
-{
-  local script=$1
-  local theme=$2
-  [ -f "$script" ] && . $script
-  ln -fs $script "$BASE16_SHELL_COLORSCHEME_PATH"
+# Allow users to optionally configure their tmux plugin path and set
+# the value if one doesn't exist
+if [ -z "$BASE16_TMUX_PLUGIN_PATH" ]; then
+  BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+fi
 
-  # If base16-tmux is used, provide a file to source when the theme
-  # changes
+# Create the config path if the path doesn't currently exist
+if [ ! -d "$BASE16_CONFIG_PATH" ]; then
+  mkdir -p "$BASE16_CONFIG_PATH"
+fi
+
+# ----------------------------------------------------------------------
+# Functions
+# ----------------------------------------------------------------------
+
+set_theme()
+{
+  local theme_name=$1
+  local script_path="$BASE16_SHELL_PATH/scripts/base16-$theme_name.sh"
+
+  if [ ! -e $BASE16_CONFIG_PATH ]; then
+    echo "\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this script \
+      and then try again"
+    return 2
+  fi
+
+  if [ -z $theme_name ]; then
+    echo "Provide a theme name to set_theme or ensure \
+      \$BASE16_THEME_DEFAULT is set"
+    return 1
+  fi
+
+  # Symlink new colorscheme
+  ln -fs "$script_path" "$BASE16_SHELL_COLORSCHEME_PATH"
+  if [ ! -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
+    echo "Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH \
+      and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    return 2
+  fi
+
+  # Source newly symlinked file
+  [ -f "$BASE16_SHELL_COLORSCHEME_PATH" ] \
+    && . "$BASE16_SHELL_COLORSCHEME_PATH"
+
+  # If base16-tmux is used, provide a file for base16-tmux to source
   if [ -e "$BASE16_TMUX_PLUGIN_PATH" ]; then 
-    echo -e "set -g \0100colors-base16 '$theme'" >| \
+    echo -e "set -g \0100colors-base16 '$theme_name'" >| \
       "$BASE16_SHELL_TMUXCONF_PATH"
   fi
 
@@ -41,26 +79,34 @@ _base16()
   fi
 }
 
-if [ -n "$BASE16_THEME_DEFAULT" ] \
-  && [ ! -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
-  ln -s \
-    "$BASE16_SHELL_PATH/scripts/base16-$BASE16_THEME_DEFAULT.sh" \
-    "$BASE16_SHELL_COLORSCHEME_PATH"
-fi
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
 
-if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
-  . "$BASE16_SHELL_COLORSCHEME_PATH"
-fi
-
-# Set base16_* aliases
-for script in "$BASE16_SHELL_PATH"/scripts/base16*.sh; do
-  script_name=${script##*/}
-  script_name=${script_name%.sh}
-  theme=${script_name#*-}
-  func_name="base16_${theme}"
-  alias $func_name="_base16 \"${script}\" ${theme}"
-done;
-
+# Reload the $BASE16_SHELL_COLORSCHEME_PATH when the shell is reset
 alias reset="command reset \
   && [ -f $BASE16_SHELL_COLORSCHEME_PATH ] \
   && . $BASE16_SHELL_COLORSCHEME_PATH"
+
+# Set base16_* aliases
+for script_path in "$BASE16_SHELL_PATH"/scripts/base16*.sh; do
+  script_name=${script_path##*/}
+  script_name=${script_name%.sh}
+  theme_name=${script_name#*-} # eg: solarized-light
+  function_name="base16_${theme_name}"
+
+  alias $function_name="set_theme \"${theme_name}\""
+done;
+
+# Load the active theme
+if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
+  # Get the active theme name from the export variable in the script
+  current_theme_name=$(grep -P 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
+  current_theme_name=${current_theme_name#*=}
+  set_theme "$current_theme_name"
+# If a colorscheme file doesn't exist and BASE16_THEME_DEFAULT is set,
+# then create the colorscheme file based on the BASE16_THEME_DEFAULT
+# scheme name
+elif [ -n "$BASE16_THEME_DEFAULT" ]; then
+  set_theme "$BASE16_THEME_DEFAULT"
+fi


### PR DESCRIPTION
Organize the scripts a little bit more and have them closely resemble each other to make them easier to understand for people who aren't familiar with both bash/zsh and fish.