### PR TITLE
Use base16-shell hook concept internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,15 @@ end
 
 ### Base16-Tmux Users
 
-This section is for [base16-tmux][3] users. base16-shell will update (or
-create) the `$HOME/.config/base16-project/tmux.base16.conf` file and
-set the colorscheme. You need to source this file in your `.tmux.conf`.
-You can do this by adding the following to your `.tmux.conf`:
+This section is for [base16-tmux][3] users who have installed
+[base16-tmux][3] through [TPM][10]. base16-shell will update (or create)
+the `$HOME/.config/base16-project/tmux.base16.conf` file and set the
+colorscheme. You need to source this file in your `.tmux.conf`. You can
+do this by adding the following to your `.tmux.conf`:
 
 ```
 source-file $HOME/.config/base16-project/tmux.base16.conf
 ```
-
-Make sure to reload your `.tmux.conf` file after the theme has been
-updated through `profile_helper`.
 
 ### Keeping your themes up to date
 
@@ -134,8 +132,32 @@ For example: `$BASE16_THEME_DEFAULT="solarized-light"`
 
 ## Usage
 
-Open a new shell and type `base16` followed by a tab to perform tab
-completion.
+### Bash/ZSH
+
+Theme aliases are prefixed with `base16_`. Type that in the command line
+and press tab to perform tab-completion.
+
+All relevant scripts have the extension `.sh`
+
+### Fish
+
+Theme aliases are prefixed with `base16-`. Type that in the command line
+and press tab to perform tab-completion.
+
+All relevant scripts have the extension `.fish`
+
+### Base16-shell hooks
+
+You can create your own base16-shell hooks. These scripts will execute
+every time you use base16-shell to change your theme. When a theme is
+changed via the command line alias prefixes, all executable scripts will
+then be sourced. 
+
+The hooks are used to switch the [base16-tmux][3] theme. If you want to
+use your own `$BASE16_SHELL_HOOKS_PATH` directory, make sure to copy the
+`$BASE16_SHELL_PATH/hooks` files across and set the
+`$BASE16_SHELL_HOOKS_PATH` variable before sourcing base16-shell
+profile_helper.
 
 ## Troubleshooting
 
@@ -170,3 +192,4 @@ instructions.
 [7]: CONTRIBUTING.md
 [8]: screenshots/base16-shell.png
 [9]: screenshots/setting-256-colourspace-not-supported.png
+[10]: https://github.com/tmux-plugins/tpm

--- a/hooks/base16-tmux.fish
+++ b/hooks/base16-tmux.fish
@@ -1,0 +1,35 @@
+#!/usr/bin/env fish
+
+# ----------------------------------------------------------------------
+# Setup config variables and env
+# ----------------------------------------------------------------------
+
+# Allow users to optionally configure their tmux plugin path and set the
+# value if one doesn't exist. This runs each time a script is switched
+# so it's important to check for previously set values.
+
+if test -z "$BASE16_SHELL_TMUXCONF_PATH"
+  set -g BASE16_SHELL_TMUXCONF_PATH "$BASE16_CONFIG_PATH/tmux.base16.conf"
+end
+
+if test -z "$BASE16_TMUX_PLUGIN_PATH"
+  set -g BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
+end
+
+# If base16-tmux path directory doesn't exist, stop hook
+if not test -d $BASE16_TMUX_PLUGIN_PATH
+  return 2
+end
+
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
+
+# If base16-tmux is used, provide a file for base16-tmux to source
+if test -d "$BASE16_TMUX_PLUGIN_PATH"
+  echo "set -g @colors-base16 '$BASE16_THEME'" > \
+    "$BASE16_SHELL_TMUXCONF_PATH"
+
+  # Source tmux config
+  tmux source-file $(tmux display-message -p "#{config_files}")
+end

--- a/hooks/base16-tmux.sh
+++ b/hooks/base16-tmux.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# Setup config variables and env
+# ----------------------------------------------------------------------
+
+# Allow users to optionally configure their tmux plugin path and set the
+# value if one doesn't exist. This runs each time a script is switched
+# so it's important to check for previously set values.
+
+if [ -z "$BASE16_SHELL_TMUXCONF_PATH" ]; then
+  BASE16_SHELL_TMUXCONF_PATH="$BASE16_CONFIG_PATH/tmux.base16.conf"
+fi
+
+if [ -z "$BASE16_TMUX_PLUGIN_PATH" ]; then
+  BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+fi
+
+# If base16-tmux path directory doesn't exist, stop hook
+if [ ! -d $BASE16_TMUX_PLUGIN_PATH ]; then
+  return 2
+fi
+
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
+
+# If base16-tmux is used, provide a file for base16-tmux to source
+if [ -d "$BASE16_TMUX_PLUGIN_PATH" ]; then 
+  echo -e "set -g \0100colors-base16 '$theme_name'" >| \
+    "$BASE16_SHELL_TMUXCONF_PATH"
+
+  # Source tmux config
+  tmux source-file $(tmux display-message -p "#{config_files}")
+fi

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -7,8 +7,6 @@
 set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
 set BASE16_SHELL_COLORSCHEME_PATH \
   "$BASE16_CONFIG_PATH/base16_shell_theme"
-set BASE16_SHELL_TMUXCONF_PATH "$BASE16_CONFIG_PATH/tmux.base16.conf"
-set BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
 
 # Allow users to optionally configure their base16-shell path and set
 # the value if one doesn't exist
@@ -16,10 +14,10 @@ if test -z $BASE16_SHELL_PATH
   set -g BASE16_SHELL_PATH (cd (dirname (status -f)); and pwd)
 end
 
-# Allow users to optionally configure their tmux plugin path and set
-# the value if one doesn't exist
-if test -z $BASE16_TMUX_PLUGIN_PATH
-  set BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
+# If the user hasn't specified a hooks dir path or it is invalid, use
+# the existing path
+if test -z "$BASE16_SHELL_HOOKS_PATH"; or not test -d "$BASE16_SHELL_HOOKS_PATH"
+  set -g BASE16_SHELL_HOOKS_PATH "$BASE16_SHELL_PATH/hooks"
 end
 
 # Create the config path if the path doesn't currently exist
@@ -64,17 +62,12 @@ function set_theme
     set -g BASE16_THEME "$theme_name"
   end
 
-  # If base16-tmux is used, provide a file for base16-tmux to source
-  if test -e "$BASE16_TMUX_PLUGIN_PATH"
-    echo "set -g @colors-base16 '$theme_name'" > \
-      "$BASE16_SHELL_TMUXCONF_PATH"
-  end
-
-  if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
-    for hook in $BASE16_SHELL_HOOKS/*
-      test -f "$hook"; and test -x "$hook"; and "$hook"
+  if test -d "$BASE16_SHELL_HOOKS_PATH"; \
+    and test (count $BASE16_SHELL_HOOKS_PATH) -eq 1;
+    for hook in $BASE16_SHELL_HOOKS_PATH/*.fish
+      test -x "$hook"; and source "$hook"
     end
-   end
+  end
 end
 
 # ----------------------------------------------------------------------

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -6,8 +6,6 @@
 
 BASE16_CONFIG_PATH="$HOME/.config/base16-project"
 BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
-BASE16_SHELL_TMUXCONF_PATH="$BASE16_CONFIG_PATH/tmux.base16.conf"
-BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
 
 # Allow users to optionally configure their base16-shell path and set
 # the value if one doesn't exist
@@ -21,10 +19,10 @@ if [ -z "$BASE16_SHELL_PATH" ]; then
   BASE16_SHELL_PATH=${script_path%/*}
 fi
 
-# Allow users to optionally configure their tmux plugin path and set
-# the value if one doesn't exist
-if [ -z "$BASE16_TMUX_PLUGIN_PATH" ]; then
-  BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+# If the user hasn't specified a hooks dir path or it is invalid, use
+# the existing path
+if [ -z "$BASE16_SHELL_HOOKS_PATH" ] && [ ! -d "$BASE16_SHELL_HOOKS_PATH" ]; then
+  BASE16_SHELL_HOOKS_PATH="$BASE16_SHELL_PATH/hooks"
 fi
 
 # Create the config path if the path doesn't currently exist
@@ -65,16 +63,9 @@ set_theme()
   [ -f "$BASE16_SHELL_COLORSCHEME_PATH" ] \
     && . "$BASE16_SHELL_COLORSCHEME_PATH"
 
-  # If base16-tmux is used, provide a file for base16-tmux to source
-  if [ -e "$BASE16_TMUX_PLUGIN_PATH" ]; then 
-    echo -e "set -g \0100colors-base16 '$theme_name'" >| \
-      "$BASE16_SHELL_TMUXCONF_PATH"
-  fi
-
-  if [ -n ${BASE16_SHELL_HOOKS:+s} ] \
-    && [ -d "${BASE16_SHELL_HOOKS}" ]; then
-    for hook in $BASE16_SHELL_HOOKS/*; do
-      [ -f "$hook" ] && [ -x "$hook" ] && "$hook"
+  if [ -d "${BASE16_SHELL_HOOKS_PATH}" ]; then
+    for hook in $BASE16_SHELL_HOOKS_PATH/*.sh; do
+      [ -x "$hook" ] && . "$hook"
     done
   fi
 }


### PR DESCRIPTION
This PR is based (via github) on https://github.com/base16-project/base16-shell/pull/2

- Move base16-tmux support into base16-shell hook
- Fix fish bug by allowing hooks to work with fish
- Add support for automatically sourcing tmux config
- Rename BASE16_SHELL_HOOKS to BASE16_SHELL_HOOKS_PATH to be consistent
  with our current variable naming conventions