### PR TITLE
Add base16 fzf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ do this by adding the following to your `.tmux.conf`:
 source-file $HOME/.config/base16-project/tmux.base16.conf
 ```
 
+### Base16-FZF Users
+
+This section is for [base16-fzf][11] users. If you have cloned
+[base16-fzf][11] to `$HOME/.config/base16-fzf` the base16-shell hook
+will work automatically. If you want to clone [base16-fzf][11] to a
+different path, make sure to have the `$BASE16_FZF_PATH` environment
+variable set in your `.*rc` file before the base16-shell script is
+sourced.
+
 ### Keeping your themes up to date
 
 To update, just `git pull` wherever you've cloned `base16-shell`. The
@@ -193,3 +202,4 @@ instructions.
 [8]: screenshots/base16-shell.png
 [9]: screenshots/setting-256-colourspace-not-supported.png
 [10]: https://github.com/tmux-plugins/tpm
+[11]: https://github.com/base16-project/base16-fzf

--- a/hooks/base16-fzf.fish
+++ b/hooks/base16-fzf.fish
@@ -1,0 +1,32 @@
+#!/usr/bin/env fish
+
+# ----------------------------------------------------------------------
+# Setup config variables and env
+# ----------------------------------------------------------------------
+
+# Allow users to optionally configure their fzf plugin path and set the
+# value if one doesn't exist. This runs each time a script is switched
+# so it's important to check for previously set values.
+
+if test -z "$BASE16_FZF_PATH"
+  set -g BASE16_FZF_PATH "$HOME/.config/base16-fzf"
+end
+
+# If BASE16_FZF_PATH doesn't exist, stop hook
+if not test -d "$BASE16_FZF_PATH"
+  return 2
+end
+
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
+
+# If base16-tmux is used, provide a file for base16-tmux to source
+if test -e "$BASE16_FZF_PATH/fish/base16-$BASE16_THEME.fish"
+  source "$BASE16_FZF_PATH/fish/base16-$BASE16_THEME.fish"
+else
+  set output string join ' ' \
+   "\$BASE16_FZF_PATH doesn't seem to be a clone of the " \
+   "base16-fzf GitHub repository."
+  echo $output
+end

--- a/hooks/base16-fzf.sh
+++ b/hooks/base16-fzf.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------
+# Setup config variables and env
+# ----------------------------------------------------------------------
+
+# Allow users to optionally configure their fzf plugin path and set the
+# value if one doesn't exist. This runs each time a script is switched
+# so it's important to check for previously set values.
+
+if [ -z "$BASE16_FZF_PATH" ]; then
+  BASE16_FZF_PATH="$HOME/.config/base16-fzf"
+fi
+
+# If BASE16_FZF_PATH doesn't exist, stop hook
+if [ ! -d "$BASE16_FZF_PATH" ]; then
+  return 2
+fi
+
+# ----------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------
+
+# If base16-tmux is used, provide a file for base16-tmux to source
+if [ -e "$BASE16_FZF_PATH/bash/base16-$BASE16_THEME.config" ]; then 
+  source "$BASE16_FZF_PATH/bash/base16-$BASE16_THEME.config"
+else
+  output="'$BASE16_THEME' theme could not be found. "
+  output+="Make sure '$BASE16_FZF_PATH' is running the most up-to-date "
+  output+="version by doing a 'git pull' in the repository directory."
+  echo $output
+fi

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -33,14 +33,18 @@ function set_theme
   set theme_name $argv[1]
 
   if not test -e $BASE16_CONFIG_PATH
-    echo "\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this script \
-      and then try again"
+    set output string join ' ' \
+      "\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this script" \
+      "and then try again"
+    echo $output
     return 2
   end
 
   if test -z $theme_name
-    echo "Provide a theme name to set_theme or ensure \
-      \$BASE16_THEME_DEFAULT is set"
+    set output string join ' ' \
+      "Provide a theme name to set_theme or ensure" \
+      "\$BASE16_THEME_DEFAULT is set"
+    echo $output
     return 1
   end
 
@@ -49,8 +53,10 @@ function set_theme
     "$BASE16_SHELL_PATH/scripts/base16-$theme_name.sh" \
     "$BASE16_SHELL_COLORSCHEME_PATH"
   if not test -e "$BASE16_SHELL_COLORSCHEME_PATH"
-    echo "Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH \
-    and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    set output string join ' ' \
+      "Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH" \
+      "and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    echo $output
     return 2
   end
 

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -40,22 +40,25 @@ set_theme()
   local script_path="$BASE16_SHELL_PATH/scripts/base16-$theme_name.sh"
 
   if [ ! -e $BASE16_CONFIG_PATH ]; then
-    echo "\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this script \
-      and then try again"
+    output="\$BASE16_CONFIG_PATH doesn't exist. Try sourcing this "
+    output+="script and then try again"
+    echo $output
     return 2
   fi
 
   if [ -z $theme_name ]; then
-    echo "Provide a theme name to set_theme or ensure \
-      \$BASE16_THEME_DEFAULT is set"
+    output="Provide a theme name to set_theme or ensure "
+    output+="\$BASE16_THEME_DEFAULT is set"
+    echo $output
     return 1
   fi
 
   # Symlink new colorscheme
   ln -fs "$script_path" "$BASE16_SHELL_COLORSCHEME_PATH"
   if [ ! -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
-    echo "Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH \
-      and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    output="Attempted symbolic link failed. Ensure \$BASE16_SHELL_PATH "
+    output+="and \$BASE16_SHELL_COLORSCHEME_PATH are valid paths."
+    echo $output
     return 2
   fi
 


### PR DESCRIPTION
This pr is based (via github) on https://github.com/base16-project/base16-shell/pull/3. It uses the base16-shell internal hooks added by the previous PR.

Add an internal base16-shell hook to allow for base16-fzf support.