### PR TITLE
Feature request: provide a way for terminals to sync with last used theme

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -46,6 +46,8 @@ for SCRIPT in $BASE16_SHELL_PATH/scripts/*.sh
       echo "set -g @colors-base16 '$partial_theme_name'" > "$BASE16_SHELL_TMUXCONF_PATH"
     end
 
+    echo "$partial_theme_name" > "$HOME/.config/base16-theme"
+
     if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
       for hook in $BASE16_SHELL_HOOKS/*
         test -f "$hook"; and test -x "$hook"; and "$hook"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -28,7 +28,7 @@ _base16()
 
   # If base16-tmux is used, provide a file to source when the theme
   # changes
-  if [ -e "$BASE16_TMUX_PLUGIN_PATH" ]; then 
+  if [ -e "$BASE16_TMUX_PLUGIN_PATH" ]; then
     echo -e "set -g \0100colors-base16 '$theme'" >| \
       "$BASE16_SHELL_TMUXCONF_PATH"
   fi
@@ -58,7 +58,7 @@ for script in "$BASE16_SHELL_PATH"/scripts/base16*.sh; do
   script_name=${script_name%.sh}
   theme=${script_name#*-}
   func_name="base16_${theme}"
-  alias $func_name="_base16 \"${script}\" ${theme}"
+  alias $func_name="_base16 \"${script}\" ${theme} && echo \"${theme}\" > \"$HOME/.config/base16-theme\""
 done;
 
 alias reset="command reset \


### PR DESCRIPTION
This one adds to `profile-helper.*` scripts the ability to write the last used theme name to a file (currently using `~/.config/base16-theme')

This is the best way I can think of to make previously opened terminals (running different shells, even) aware of a `base16` theme change...

Hopefully, in the future, this feature will be adopted by all terminals and/or terminal apps apps