### PR TITLE
Fix permission issue on tmux.conf

### DIFF
--- a/hooks/base16-tmux.sh
+++ b/hooks/base16-tmux.sh
@@ -8,11 +8,11 @@
 # value if one doesn't exist. This runs each time a script is switched
 # so it's important to check for previously set values.
 
-if [ -z "$BASE16_SHELL_TMUXCONF_PATH" ]; then
+if [ -n "$BASE16_SHELL_TMUXCONF_PATH" ]; then
   BASE16_SHELL_TMUXCONF_PATH="$BASE16_CONFIG_PATH/tmux.base16.conf"
 fi
 
-if [ -z "$BASE16_TMUX_PLUGIN_PATH" ]; then
+if [ -n "$BASE16_TMUX_PLUGIN_PATH" ]; then
   BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
 fi
 


### PR DESCRIPTION
Since the introduction of hooks I am now getting the following error when starting a new terminal - without having custom config paths set - looks like it is down to the variable checking in bash.

```bash
home/user/.zplug/repos/base16-project/base16-shell/hooks/base16-tmux.sh: line 30: /tmux.base16.conf: Permission denied
```