### PR TITLE
Remove -P flag from grep call to increase compatibility.

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -97,7 +97,7 @@ end
 if test -e "$BASE16_SHELL_COLORSCHEME_PATH"
   # Get the active theme name from the export variable in the script
   set current_theme_name \
-    $(grep -P 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
+    $(grep 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
   set current_theme_name \
     $(string replace -r 'export BASE16_THEME=' '' $current_theme_name)
   set_theme "$current_theme_name"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -98,7 +98,7 @@ fi
 # Load the active theme
 if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
   # Get the active theme name from the export variable in the script
-  current_theme_name=$(grep -P 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
+  current_theme_name=$(grep 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
   current_theme_name=${current_theme_name#*=}
   set_theme "$current_theme_name"
 # If a colorscheme file doesn't exist and BASE16_THEME_DEFAULT is set,


### PR DESCRIPTION
I struggled a bit setting up the current version of `base16-shell` on a new machine.
After digging through it I came across the `grep -P` call in [`profile_helper.sh`](https://github.com/base16-project/base16-shell/blob/main/profile_helper.sh#L101).

The -P flag, or --perl-regexp, is not available in the grep command that ships with macOS (tested on Monterey), so when zsh initialised it printed out some errors mentioning that `-P` is not supported.

The good news is that the search pattern used in this grep call doesn't contain any Perl specific elements so I thought we could remove it altogether without affecting functionality.