### PR TITLE
Switch return to exit to prevent shell errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add following lines to `.bashrc` or `.zshrc`:
 BASE16_SHELL_PATH="$HOME/.config/base16-shell"
 [ -n "$PS1" ] && \
   [ -s "$BASE16_SHELL_PATH/profile_helper.sh" ] && \
-    source "$BASE16_SHELL_PATH/profile_helper.sh"
+    "$BASE16_SHELL_PATH/profile_helper.sh"
 ```
 
 ### Oh my zsh

--- a/base16-shell.plugin.bash
+++ b/base16-shell.plugin.bash
@@ -2,5 +2,5 @@ script_path=${BASH_SOURCE[0]}
 script_path=$(readlink -f $script_path)
 BASE16_SHELL_PATH=${script_path%/*}
 
-[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && source \
+[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && \
   "$BASE16_SHELL_PATH/profile_helper.sh"

--- a/base16-shell.plugin.zsh
+++ b/base16-shell.plugin.zsh
@@ -2,5 +2,5 @@ script_path=${(%):-%x}
 script_path=$(readlink -f $script_path)
 BASE16_SHELL_PATH=${script_path%/*}
 
-[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && source \
+[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && \
   "$BASE16_SHELL_PATH/profile_helper.sh"

--- a/hooks/base16-fzf.sh
+++ b/hooks/base16-fzf.sh
@@ -14,7 +14,7 @@ fi
 
 # If BASE16_FZF_PATH doesn't exist, stop hook
 if [ ! -d "$BASE16_FZF_PATH" ]; then
-  return 2
+  exit 2
 fi
 
 # ----------------------------------------------------------------------

--- a/hooks/base16-hexchat.sh
+++ b/hooks/base16-hexchat.sh
@@ -14,12 +14,12 @@ fi
 
 # If BASE16_HEXCHAT_PATH doesn't exist, stop hook
 if [ ! -d "$BASE16_HEXCHAT_PATH" ]; then
-  return 2
+  exit 2
 fi
 
 # If HEXCHAT_COLORS_CONF_PATH hasn't been configured, stop hook
 if [ -z "$HEXCHAT_COLORS_CONF_PATH" ]; then
-  return 1
+  exit 1
 fi
 
 # If HEXCHAT_COLORS_CONF_PATH has been configured, but the file doesn't
@@ -27,7 +27,7 @@ fi
 if [ -n "$HEXCHAT_COLORS_CONF_PATH" ] \
   && [ ! -f "$HEXCHAT_COLORS_CONF_PATH" ]; then
   echo "\$HEXCHAT_COLORS_CONF_PATH is not a file."
-  return 2
+  exit 2
 fi
 
 hexchat_theme_path="$BASE16_HEXCHAT_PATH/colors/base16-$BASE16_THEME.conf"
@@ -39,7 +39,7 @@ if [ ! -f "$hexchat_theme_path" ]; \
   output+="the directory and try doing a \`git pull\`."
 
   echo $output
-  return 2
+  exit 2
 fi
 
 # ----------------------------------------------------------------------

--- a/hooks/base16-tmux.sh
+++ b/hooks/base16-tmux.sh
@@ -18,7 +18,7 @@ fi
 
 # If base16-tmux path directory doesn't exist, stop hook
 if [ ! -d $BASE16_TMUX_PLUGIN_PATH ]; then
-  return 2
+  exit 2
 fi
 
 # ----------------------------------------------------------------------

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -65,7 +65,7 @@ set_theme()
 
   if [ -d "${BASE16_SHELL_HOOKS_PATH}" ]; then
     for hook in $BASE16_SHELL_HOOKS_PATH/*.sh; do
-      [ -x "$hook" ] && . "$hook"
+      [ -x "$hook" ] && "$hook"
     done
   fi
 }
@@ -91,19 +91,17 @@ done;
 
 # If $BASE16_THEME is set, this has already been loaded. This guards
 # against a bug where this script is sourced two or more times.
-if [ -n "$BASE16_THEME" ]; then
-  return 1
-fi
-
-# Load the active theme
-if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
-  # Get the active theme name from the export variable in the script
-  current_theme_name=$(grep 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
-  current_theme_name=${current_theme_name#*=}
-  set_theme "$current_theme_name"
-# If a colorscheme file doesn't exist and BASE16_THEME_DEFAULT is set,
-# then create the colorscheme file based on the BASE16_THEME_DEFAULT
-# scheme name
-elif [ -n "$BASE16_THEME_DEFAULT" ]; then
-  set_theme "$BASE16_THEME_DEFAULT"
+if [ -z "$BASE16_THEME" ]; then
+  # Load the active theme
+  if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
+    # Get the active theme name from the export variable in the script
+    current_theme_name=$(grep 'export BASE16_THEME' "$BASE16_SHELL_COLORSCHEME_PATH")
+    current_theme_name=${current_theme_name#*=}
+    set_theme "$current_theme_name"
+  # If a colorscheme file doesn't exist and BASE16_THEME_DEFAULT is set,
+  # then create the colorscheme file based on the BASE16_THEME_DEFAULT
+  # scheme name
+  elif [ -n "$BASE16_THEME_DEFAULT" ]; then
+    set_theme "$BASE16_THEME_DEFAULT"
+  fi
 fi


### PR DESCRIPTION
fixes issue with `return` appearing outside of function:
```
Cannot source /home/josh/.config/zsh/.zcomet/repos/base16-project/base16-shell/base16-shell.plugin.zsh.
❱ $BASE16_SHELL_PATH/profile_helper.sh
/home/josh/.config/zsh/.zcomet/repos/base16-project/base16-shell/profile_helper.sh: line 95: return: can only `return' from a function or sourced script
```