### PR TITLE
Don't return non-zero if already loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 schemes
+*.zwc

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -92,7 +92,7 @@ done;
 # If $BASE16_THEME is set, this has already been loaded. This guards
 # against a bug where this script is sourced two or more times.
 if [ -n "$BASE16_THEME" ]; then
-  return 1
+  return 0
 fi
 
 # Load the active theme


### PR DESCRIPTION
@JamyGolden this is a much simpler change - it turns out it was only the non-zero return that was the problem (my ZSH package manager `zcomet` wasn't happy with the non-zero return)