### PR TITLE
Add support to optionally export color variables for custom usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ and press tab to perform tab-completion.
 
 All relevant scripts have the extension `.fish`
 
+### Customization using base16-shell
+
+There are times when base16 templates don't exist for command line
+applications, or perhaps you just want to play around with base16
+colors. For those situations you can access active base16-shell theme
+colors via `BASE16_COLOR_01_HEX` to `BASE16_COLOR_09_HEX` for colors 0-9
+and `BASE16_COLOR_0A_HEX` to `BASE16_COLOR_0F_HEX` for colors 10-16.
+Have a look at the [styling guidlines][13] for more information.
+
+To enable this feature, make sure to export `BASE16_SHELL_ENABLE_VARS=1`
+before base16-shell is loaded.
+
 ## Troubleshooting
 
 Run the included **colortest** script and check that your colour
@@ -216,3 +228,4 @@ instructions.
 [10]: https://github.com/tmux-plugins/tpm
 [11]: https://github.com/base16-project/base16-fzf
 [12]: https://github.com/base16-project/base16-hexchat
+[13]: https://github.com/base16-project/home/blob/main/styling.md

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -125,3 +125,23 @@ unset color20
 unset color21
 unset color_foreground
 unset color_background
+
+# Optionally export variables
+if [ -n "$BASE16_SHELL_ENABLE_VARS" ]; then
+  export BASE16_COLOR_00_HEX="{{base00-hex}}"
+  export BASE16_COLOR_01_HEX="{{base01-hex}}"
+  export BASE16_COLOR_02_HEX="{{base02-hex}}"
+  export BASE16_COLOR_03_HEX="{{base03-hex}}"
+  export BASE16_COLOR_04_HEX="{{base04-hex}}"
+  export BASE16_COLOR_05_HEX="{{base05-hex}}"
+  export BASE16_COLOR_06_HEX="{{base06-hex}}"
+  export BASE16_COLOR_07_HEX="{{base07-hex}}"
+  export BASE16_COLOR_08_HEX="{{base08-hex}}"
+  export BASE16_COLOR_09_HEX="{{base09-hex}}"
+  export BASE16_COLOR_0A_HEX="{{base0A-hex}}"
+  export BASE16_COLOR_0B_HEX="{{base0B-hex}}"
+  export BASE16_COLOR_0C_HEX="{{base0C-hex}}"
+  export BASE16_COLOR_0D_HEX="{{base0D-hex}}"
+  export BASE16_COLOR_0E_HEX="{{base0E-hex}}"
+  export BASE16_COLOR_0F_HEX="{{base0F-hex}}"
+fi


### PR DESCRIPTION
It was brought up in this issue that it would be useful to export variables for custom usage: https://github.com/base16-project/base16-shell/issues/13

I agree that it makes sense. Sometimes templates don't exist and there's no reason not to make it easy for people to play around with these values. I've exported it optionally in the template, so it doesn't litter the global env if a user doesn't want that.