### PR TITLE
Support custom output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ You can customize where the generated configuration of this script is
 stored by setting the `$BASE16_CONFIG_PATH` environment variable before
 the `profile_helper` script is loaded. This variable defaults to
 `$HOME/.config/base16-project`.
-> If you are using oh-my-zsh you need to set this variable before 
+
+If you are using oh-my-zsh you need to set this variable before 
 `oh-my-zsh.sh` is sourced in your `.zshrc`.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ first time.
 
 For example: `$BASE16_THEME_DEFAULT="solarized-light"` 
 
+### Default config path
+
+You can customize where the generated configuration of this script is 
+stored by setting the `$BASE16_CONFIG_PATH` environment variable before
+the `profile_helper` script is loaded. This variable defaults to
+`$HOME/.config/base16-project`.
+> If you are using oh-my-zsh you need to set this variable before 
+`oh-my-zsh.sh` is sourced in your `.zshrc`.
+
 ## Usage
 
 ### Bash/ZSH

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -4,7 +4,11 @@
 # Setup variables and env
 # ----------------------------------------------------------------------
 
-set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
+# Allow users to optionally configure where their base16-shell config is
+# stored by specifying BASE16_CONFIG_PATH before loading this script
+if test -z $BASE16_CONFIG_PATH
+  set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
+end
 set BASE16_SHELL_COLORSCHEME_PATH \
   "$BASE16_CONFIG_PATH/base16_shell_theme"
 

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -4,7 +4,9 @@
 # Setup config variables and env
 # ----------------------------------------------------------------------
 
-BASE16_CONFIG_PATH="$HOME/.config/base16-project"
+# Allow users to optionally configure where their base16-shell config is
+# stored by specifying BASE16_CONFIG_PATH before loading this script
+BASE16_CONFIG_PATH="${BASE16_CONFIG_PATH:=$HOME/.config/base16-project}"
 BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
 
 # Allow users to optionally configure their base16-shell path and set


### PR DESCRIPTION
This PR enables users to customize the output directory of the `profile-helper` script.

It should make it easier for users to follow the XDG specification ([source](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)) ([better docs](https://wiki.archlinux.org/title/XDG_Base_Directory)).

I don't have `fish` setup locally so would appreciate extra verification of those changes.