### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/shell
+* @tinted-theming/shell

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 title: "[Bug report] "
 labels: ["bug"]
 assignees: 
-  - base16-project/shell
+  - tinted-theming/shell
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: "[Feature request] "
 labels: ["feature"]
 assignees: 
-  - base16-project/shell
+  - tinted-theming/shell
 ---
 
 ## Is your feature request related to a problem? Please describe.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update with the latest colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Or the above steps represented in shell commands:
 
 ```shell 
 cd /path/to/base16-shell/../ # This repos parent dir 
-git clone git@github.com:base16-project/base16-builder-go.git
+git clone git@github.com:tinted-theming/base16-builder-go.git
 cd base16-builder-go
 go build ./base16-builder-go/base16-builder-go \
   -template-dir ../base16-shell
@@ -59,8 +59,8 @@ Please follow the instructions in the issue templates:
 - [Issue template for bug reports][5]
 - [Issue template for feature requests][6]
 
-[1]: https://github.com/base16-project/base16-builder-go
-[2]: https://github.com/base16-project/base16-schemes
+[1]: https://github.com/tinted-theming/base16-builder-go
+[2]: https://github.com/tinted-theming/base16-schemes
 [3]: .github/workflows/update.yml
 [4]: .github/pull_request_template.md
 [5]: .github/ISSUE_TEMPLATE/bug_report.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,6 +3,7 @@
 Base16 Shell is released under the MIT License:
 
 > Copyright (C) 2012 [Chris Kempson](http://chriskempson.com)
+> Copyright (C) 2022 [Tinted Theming](https://github.com/tinted-theming)
 > 
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ as Vim and tmux.
 ## Installation
 
 ```shell
-git clone https://github.com/base16-project/base16-shell.git \
+git clone https://github.com/tinted-theming/base16-shell.git \
   $HOME/.config/base16-shell
 ```
 
@@ -112,9 +112,9 @@ your theme, but Vim loads with the theme you initialised TMUX with.
 **Vim**
 
 ```vim
-if filereadable(expand("$HOME/.config/base16-project/set_theme.vim"))
+if filereadable(expand("$HOME/.config/tinted-theming/set_theme.vim"))
   let base16colorspace=256
-  source $HOME/.config/base16-project/set_theme.vim
+  source $HOME/.config/tinted-theming/set_theme.vim
 endif
 ```
 
@@ -123,7 +123,7 @@ endif
 ```lua
 local fn = vim.fn
 local cmd = vim.cmd
-local set_theme_path = "$HOME/.config/base16-project/set_theme.lua"
+local set_theme_path = "$HOME/.config/tinted-theming/set_theme.lua"
 local is_set_theme_file_readable = fn.filereadable(fn.expand(set_theme_path)) == 1 and true or false
 
 if is_set_theme_file_readable then
@@ -149,12 +149,12 @@ profile_helper.
 
 You will automatically use this hook if you have installed
 [base16-tmux][3] through [TPM][10]. base16-shell will update (or create)
-the `$HOME/.config/base16-project/tmux.base16.conf` file and set the
+the `$HOME/.config/tinted-theming/tmux.base16.conf` file and set the
 colorscheme. You need to source this file in your `.tmux.conf`. You can
 do this by adding the following to your `.tmux.conf`:
 
 ```
-source-file $HOME/.config/base16-project/tmux.base16.conf
+source-file $HOME/.config/tinted-theming/tmux.base16.conf
 ```
 
 #### FZF
@@ -199,7 +199,7 @@ For example: `$BASE16_THEME_DEFAULT="solarized-light"`
 You can customize where the generated configuration of this script is 
 stored by setting the `$BASE16_CONFIG_PATH` environment variable before
 the `profile_helper` script is loaded. This variable defaults to
-`$HOME/.config/base16-project`.
+`$HOME/.config/tinted-theming`.
 
 If you are using oh-my-zsh you need to set this variable before 
 `oh-my-zsh.sh` is sourced in your `.zshrc`.
@@ -249,23 +249,23 @@ as the arguement e.g. `./colortest base16-ocean.sh`.
 ### Inverted blacks and whites
 
 This is the expected behaviour when using a light theme:
-https://github.com/base16-project/base16-shell/issues/150
+https://github.com/tinted-theming/base16-shell/issues/150
 
 ## Contributing
 
 See [`CONTRIBUTING.md`][7], which contains building and contributing
 instructions.
 
-[1]: https://github.com/base16-project/home
-[2]: https://github.com/base16-project/base16-vim
+[1]: https://github.com/tinted-theming/home
+[2]: https://github.com/tinted-theming/base16-vim
 [3]: https://github.com/mattdavis90/base16-tmux
-[4]: https://github.com/base16-project/base16-builder-go
+[4]: https://github.com/tinted-theming/base16-builder-go
 [5]: https://formulae.brew.sh
 [6]: .github/workflows/update.yml
 [7]: CONTRIBUTING.md
 [8]: screenshots/base16-shell.png
 [9]: screenshots/setting-256-colourspace-not-supported.png
 [10]: https://github.com/tmux-plugins/tpm
-[11]: https://github.com/base16-project/base16-fzf
-[12]: https://github.com/base16-project/base16-hexchat
-[13]: https://github.com/base16-project/home/blob/main/styling.md
+[11]: https://github.com/tinted-theming/base16-fzf
+[12]: https://github.com/tinted-theming/base16-hexchat
+[13]: https://github.com/tinted-theming/home/blob/main/styling.md

--- a/colortest
+++ b/colortest
@@ -62,5 +62,5 @@ for padded_value in `seq -w 0 21`; do
   printf "%s %s %s %-30s %s\x1b[0m\n" $foreground $base16_color_name $current_color_label ${ansi_label:-""} $block
 done;
 if [ $# -eq 1 ]; then
-    printf "To restore current theme, source $HOME/.config/base16-project/base16_theme or reopen your terminal\n"
+    printf "To restore current theme, source $HOME/.config/tinted-theming/base16_theme or reopen your terminal\n"
 fi

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -7,7 +7,7 @@
 # Allow users to optionally configure where their base16-shell config is
 # stored by specifying BASE16_CONFIG_PATH before loading this script
 if test -z $BASE16_CONFIG_PATH
-  set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
+  set BASE16_CONFIG_PATH "$HOME/.config/tinted-theming"
 end
 set BASE16_SHELL_COLORSCHEME_PATH \
   "$BASE16_CONFIG_PATH/base16_shell_theme"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -6,7 +6,7 @@
 
 # Allow users to optionally configure where their base16-shell config is
 # stored by specifying BASE16_CONFIG_PATH before loading this script
-BASE16_CONFIG_PATH="${BASE16_CONFIG_PATH:=$HOME/.config/base16-project}"
+BASE16_CONFIG_PATH="${BASE16_CONFIG_PATH:=$HOME/.config/tinted-theming}"
 BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
 # Store the theme name in a file so we aren't reliant on environment
 # variables to store this value alone since it can be inaccurate when

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,7 +1,8 @@
 #!/bin/sh
-# base16-shell (https://github.com/base16-project/base16-shell)
-# Base16 Shell template by base16-project (https://github.com/base16-project)
-# {{scheme-name}} scheme by {{scheme-author}}
+# base16-shell (https://github.com/tinted-theming/base16-shell)
+# Scheme name: {{scheme-name}} 
+# Scheme author: {{scheme-author}}
+# Template author: Tinted Theming (https://github.com/tinted-theming)
 export BASE16_THEME={{scheme-slug}}
 
 color00="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00 - Black


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.