### PR TITLE
Add support for XDG Base Directory Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,17 @@ use your own `$BASE16_SHELL_HOOKS_PATH` directory, make sure to copy the
 `$BASE16_SHELL_HOOKS_PATH` variable before sourcing base16-shell
 profile_helper.
 
+base16-shell follows the [XDG Base Directory Specification]. If you have
+the `$XDG_CONFIG_HOME` variable set, it will look for the `base16-*`
+cloned repos used for the shell hooks in
+`$XDG_CONFIG_HOME/tinted-theming/base16-*`.
+
 #### Tmux
 
 You will automatically use this hook if you have installed
 [base16-tmux][3] through [TPM][10]. base16-shell will update (or create)
-the `$HOME/.config/tinted-theming/tmux.base16.conf` file and set the
+the `$HOME/.config/tinted-theming/tmux.base16.conf` (or
+`$XDG_CONFIG_HOME/tinted-theming/tmux.base16.conf`) file and set the
 colorscheme. You need to source this file in your `.tmux.conf`. You can
 do this by adding the following to your `.tmux.conf`:
 
@@ -157,18 +163,32 @@ do this by adding the following to your `.tmux.conf`:
 source-file $HOME/.config/tinted-theming/tmux.base16.conf
 ```
 
+If you're using XDG, make sure to have your tmux settings installed at
+`$XDG_CONFIG_HOME/tmux`.
+
+##### XDG
+
+If you have XDG set up, make sure your tmux setup is installed at
+`$XDG_CONFIG_HOME/tmux`
+
+```
+source-file $XDG_CONFIG_HOME/tinted-theming/tmux.base16.conf
+```
+
 #### FZF
 
-Clone [base16-fzf][11] to `$HOME/.config/base16-fzf`. Once that is done
-the hook will automatically pick that up and things will work as
-expected.
+Clone [base16-fzf][11] to `$HOME/.config/tinted-theming/base16-fzf` (or
+`$XDG_CONFIG_HOME/tinted-theming/base16-fzf`). Once that is done the
+hook will automatically pick that up and things will work as expected.
 
 If you'd like to install to a different path, you can do that and set
 `$BASE16_FZF_PATH` to your custom path.
 
 #### HexChat (XChat)
 
-1. Clone [base16-hexchat][12] to `$HOME/base16-hexchat`. Or optionally
+1. Clone [base16-hexchat][12] to
+   `$HOME/.config/tinted-theming/base16-hexchat` (or
+   `$XDG_CONFIG_HOME/tinted-theming/base16-hexchat`). Or optionally
    install to a custom path and set `$BASE16_HEXCHAT_PATH` to that path.
 2. Set the `$HEXCHAT_COLORS_CONF_PATH` shell variable to your hexchat
    `colors.conf` file. If you don't know where that is, read the
@@ -269,3 +289,4 @@ instructions.
 [11]: https://github.com/tinted-theming/base16-fzf
 [12]: https://github.com/tinted-theming/base16-hexchat
 [13]: https://github.com/tinted-theming/home/blob/main/styling.md
+[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/hooks/base16-fzf.fish
+++ b/hooks/base16-fzf.fish
@@ -9,7 +9,11 @@
 # so it's important to check for previously set values.
 
 if test -z "$BASE16_FZF_PATH"
-  set -g BASE16_FZF_PATH "$HOME/.config/base16-fzf"
+  if test -n "$XDG_CONFIG_HOME"
+    set -g BASE16_FZF_PATH "$XDG_CONFIG_HOME/tinted-theming/base16-fzf"
+  else
+    set -g BASE16_FZF_PATH "$HOME/.config/tinted-theming/base16-fzf"
+  end
 end
 
 # If BASE16_FZF_PATH doesn't exist, stop hook

--- a/hooks/base16-fzf.sh
+++ b/hooks/base16-fzf.sh
@@ -9,7 +9,7 @@
 # so it's important to check for previously set values.
 
 if [ -z "$BASE16_FZF_PATH" ]; then
-  BASE16_FZF_PATH="$HOME/.config/base16-fzf"
+  BASE16_FZF_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/tinted-theming/base16-fzf"
 fi
 
 # If BASE16_FZF_PATH doesn't exist, stop hook

--- a/hooks/base16-hexchat.fish
+++ b/hooks/base16-hexchat.fish
@@ -9,7 +9,11 @@
 # switched so it's important to check for previously set values.
 
 if test -z "$BASE16_HEXCHAT_PATH"
-  set BASE16_HEXCHAT_PATH "$HOME/.config/base16-hexchat"
+  if test -n "$XDG_CONFIG_HOME"
+    set -g BASE16_HEXCHAT_PATH "$XDG_CONFIG_HOME/tinted-theming/base16-hexchat"
+  else
+    set -g BASE16_HEXCHAT_PATH "$HOME/.config/tinted-theming/base16-hexchat"
+  end
 end
 
 # If BASE16_HEXCHAT_PATH doesn't exist, stop hook

--- a/hooks/base16-hexchat.sh
+++ b/hooks/base16-hexchat.sh
@@ -9,7 +9,7 @@
 # switched so it's important to check for previously set values.
 
 if [ -z "$BASE16_HEXCHAT_PATH" ]; then
-  BASE16_HEXCHAT_PATH="$HOME/.config/base16-hexchat"
+  BASE16_HEXCHAT_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/tinted-theming/base16-hexchat"
 fi
 
 # If BASE16_HEXCHAT_PATH doesn't exist, stop hook

--- a/hooks/base16-tmux.fish
+++ b/hooks/base16-tmux.fish
@@ -13,7 +13,11 @@ if test -z "$BASE16_SHELL_TMUXCONF_PATH"
 end
 
 if test -z "$BASE16_TMUX_PLUGIN_PATH"
-  set -g BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
+  if test -n "$XDG_CONFIG_HOME"
+    set -g BASE16_HEXCHAT_PATH "$XDG_CONFIG_HOME/tmux/plugins/base16-tmux"
+  else
+    set -g BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
+  end
 end
 
 # If base16-tmux path directory doesn't exist, stop hook

--- a/hooks/base16-tmux.sh
+++ b/hooks/base16-tmux.sh
@@ -13,7 +13,11 @@ if [ -z "$BASE16_SHELL_TMUXCONF_PATH" ]; then
 fi
 
 if [ -z "$BASE16_TMUX_PLUGIN_PATH" ]; then
-  BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+  if [ -d "$XDG_CONFIG_HOME/tmux" ]; then
+    BASE16_TMUX_PLUGIN_PATH="$XDG_CONFIG_HOME/tmux/plugins/base16-tmux"
+  fi
+    BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+  else
 fi
 
 # If base16-tmux path directory doesn't exist, stop hook

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -7,7 +7,11 @@
 # Allow users to optionally configure where their base16-shell config is
 # stored by specifying BASE16_CONFIG_PATH before loading this script
 if test -z $BASE16_CONFIG_PATH
-  set BASE16_CONFIG_PATH "$HOME/.config/tinted-theming"
+  if test -n "XDG_CONFIG_HOME"
+    set -g BASE16_CONFIG_PATH "$XDG_CONFIG_HOME/tinted-theming"
+  else
+    set -g BASE16_CONFIG_PATH "$HOME/.config/tinted-theming"
+  end
 end
 set BASE16_SHELL_COLORSCHEME_PATH \
   "$BASE16_CONFIG_PATH/base16_shell_theme"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -6,7 +6,9 @@
 
 # Allow users to optionally configure where their base16-shell config is
 # stored by specifying BASE16_CONFIG_PATH before loading this script
-BASE16_CONFIG_PATH="${BASE16_CONFIG_PATH:=$HOME/.config/tinted-theming}"
+if [ -z $BASE16_CONFIG_PATH ]; then
+  BASE16_CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/tinted-theming"
+fi
 BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
 # Store the theme name in a file so we aren't reliant on environment
 # variables to store this value alone since it can be inaccurate when


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

- Ensure `base16-*` hooks are installed to `$XDG_CONFIG_HOME/tinted-theming/base16-*`; or `~/.config/tinted-theming/base16-*` if `$XDG_CONFIG_HOME` is not set.
- Hook: check for tmux config files and plugins in `$XDG_CONFIG_HOME/tmux`; or `~/.tmux` if `$XDG_CONFIG_HOME` is not set.