### PR TITLE
Unset internal loop variables to prevent leaking to shell

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -104,6 +104,9 @@ for script_path in $BASE16_SHELL_PATH/scripts/*.sh
   alias $function_name="set_theme \"$theme_name\""
 end
 
+# unset loop variables to not leak to user's shell
+set -e script_path function_name theme_name
+
 # If $BASE16_THEME is set, this has already been loaded. This guards
 # against a bug where this script is sourced two or more times.
 if test -n "$BASE16_THEME"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -98,11 +98,14 @@ alias reset="command reset \
 for script_path in "$BASE16_SHELL_PATH"/scripts/base16*.sh; do
   script_name=${script_path##*/}
   script_name=${script_name%.sh}
-  theme_name=${script_name#*-} # eg: solarized-light
+  theme_name=${script_name#base16-} # eg: solarized-light
   function_name="base16_${theme_name}"
 
   alias $function_name="set_theme \"${theme_name}\""
 done;
+
+# unset loop variables to not leak to user's shell
+unset script_path script_name theme_name function_name
 
 # If $BASE16_THEME is set, this has already been loaded. This guards
 # against a bug where this script is sourced two or more times.


### PR DESCRIPTION
Prevents leaking internal variables from loop to shell, e.g.
```bash
$ echo -e "$script_path\n$script_name\n$theme_name\n$function_name"
/home/josh/.local/share/zcomet/repos/tinted-theming/base16-shell/scripts/base16-zenburn.sh
base16-zenburn
zenburn
base16_zenburn
```
note: `zenburn` is just the last theme in the loop