### PR TITLE
fix zplug plugin load

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -84,6 +84,7 @@ set_theme()
     for hook in $BASE16_SHELL_HOOKS_PATH/*.sh; do
       [ -x "$hook" ] && . "$hook"
     done
+    unset hook
   fi
 }
 


### PR DESCRIPTION
`unset hook` inside `set_theme` so that the `hook` variable does not accidentally trigger these lines in zplug

https://github.com/zplug/zplug/blob/ac6c2a3e9eea6a488d96d98c752ef887e7d5aae3/base/core/load.zsh#L116-L117