### PR TITLE
fix: vim: Fix file existence check for set_theme.{vim,lua}

### DIFF
--- a/hooks/base16-vim.sh
+++ b/hooks/base16-vim.sh
@@ -7,11 +7,11 @@
 BASE16_SHELL_VIM_PATH="$BASE16_CONFIG_PATH/set_theme.vim"
 BASE16_SHELL_NVIM_PATH="$BASE16_CONFIG_PATH/set_theme.lua"
 
-if [ -f "$BASE16_SHELL_VIM_PATH" ]; then
+if ! [ -e "$BASE16_SHELL_VIM_PATH" ]; then
   touch "$BASE16_SHELL_VIM_PATH"
 fi
 
-if [ -f "$BASE16_SHELL_NVIM_PATH" ]; then
+if ! [ -e "$BASE16_SHELL_NVIM_PATH" ]; then
   touch "$BASE16_SHELL_NVIM_PATH"
 fi
 


### PR DESCRIPTION
Caught this bug as result of @JamyGolden's comment: https://github.com/tinted-theming/base16-shell/pull/30/files/f6a45f9afcf0b6a6fbd00b7ee4243d3a8cc872a8#r1303235223