### PR TITLE
fix(fish): avoid user functions

### DIFF
--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -66,7 +66,7 @@ function set_theme
   end
 
   # Symlink and source
-  ln -fs \
+  command ln -fs \
     "$BASE16_SHELL_PATH/scripts/base16-$theme_name.sh" \
     "$BASE16_SHELL_COLORSCHEME_PATH"
   if not test -e "$BASE16_SHELL_COLORSCHEME_PATH"


### PR DESCRIPTION
Some users wrap applications such as ln with functions for use in interactive shells, and these functions may not be appropriate in a non-interactive context - explicitly specify the ln command.