### PR TITLE
hook should not call "exit" but "return"

### DIFF
--- a/hooks/base16-sublime-merge.fish
+++ b/hooks/base16-sublime-merge.fish
@@ -5,28 +5,28 @@
 # ----------------------------------------------------------------------
 
 if test -z "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH"
-  exit 1
+  return 1
 end
 
 if not test -f "$BASE16_SHELL_THEME_NAME_PATH"
-  exit 1
+  return 1
 end
 
 # The path/to/sublime-merge/Package must be set
 if not test -d "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH"
-  exit 1
+  return 1
 end
 
 # The base16-sublime-merge repo must be cloned at
 if not test -d "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH/base16-sublime-merge"
-  exit 1
+  return 1
 end
 
 set BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH/User/Preferences.sublime-settings"
 
 # The Sublime Merge settings path should exist
 if not test -f "$BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH"
-  exit 1
+  return 1
 end
 
 function find_replace_json_value_in_sublimemerge_settings

--- a/hooks/base16-sublime-merge.sh
+++ b/hooks/base16-sublime-merge.sh
@@ -5,28 +5,28 @@
 # ----------------------------------------------------------------------
 
 if [ -z "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH" ]; then
-  exit 1
+  return 1
 fi
 
 if ! [ -f "$BASE16_SHELL_THEME_NAME_PATH" ]; then
-  exit 1
+  return 1
 fi
 
 # The path/to/sublime-merge/Package must be set
 if ! [ -d "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH" ]; then
-  exit 1
+  return 1
 fi
 
 # The base16-sublime-merge repo must be cloned at
 if ! [ -d "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH/base16-sublime-merge" ]; then
-  exit 1
+  return 1
 fi
 
 BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH="$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH"/User/Preferences.sublime-settings 
 
 # The Sublime Merge settings path should exist
 if ! [ -f "$BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH" ]; then
-  exit 1
+  return 1
 fi
 
 find_replace_json_value_in_sublimemerge_settings() {


### PR DESCRIPTION
In the new sublime hook file is an error. The hook should never call `exit` but `return`. otherwise the shell closes when sublime is not installed