### PR TITLE
Use Current theme for colortest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,10 @@ of colours in within the 256 colorspace (e.g. Apple Terminal), colours
 ![setting 256 colourspace not supported][9]
 
 If **colortest** is run without any arguments e.g. `./colortest` the hex
-values shown will correspond to the default scheme. If you'd like to see
-the hex values for a particular scheme pass the file name of the theme
-as the arguement e.g. `./colortest base16-ocean.sh`.
+values shown will correspond to the currently set theme or the default
+theme set with `BASE16_THEME_DEFAULT`. If you'd like to see the hex
+values for a particular scheme pass the file name of the theme name as
+the arguement e.g. `./colortest ocean`.
 
 ### Inverted blacks and whites
 

--- a/colortest
+++ b/colortest
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
-theme=$(dirname $0)/scripts/${1:-base16-default-dark.sh}
+
+if [[ -z $BASE16_SHELL_THEME_NAME_PATH ]]; then
+  BASE16_SHELL_THEME_NAME_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/tinted-theming/theme_name" 
+fi
+
+# If $BASE16_SHELL_THEME_NAME_PATH exists extract the file contents
+read current_theme_name_from_config_file < "$BASE16_SHELL_THEME_NAME_PATH"
+
+# Use $current_theme_name_from_config_file else $BASE16_THEME else $BASE16_THEME_DEFAULT else "default-dark"
+theme_name="${1:-${current_theme_name_from_config_file:-${BASE16_THEME:-${BASE16_THEME_DEFAULT:-default-dark}}}}"
+theme=$(dirname $0)/scripts/base16-${theme_name}.sh
 if [ -f $theme ]; then
   # get the color declarations in said theme, assumes there is a block of text that starts with color00= and ends with new line
   source $theme


### PR DESCRIPTION
Created a PR to solve this issue: https://github.com/tinted-theming/base16-shell/issues/43

Adjust `colortest` script to accept theme names instead of the whole theme script. So from `./colortest base16-ayu-dark.sh` to now `./colortest ayu-dark`.

On top of this, running `./colortest` now uses the currently set theme instead of immediatly defaulting to `default-dark` theme.