### PR TITLE
Add checks to only set hooks with existing theme

### DIFF
--- a/hooks/base16-sublime-merge.sh
+++ b/hooks/base16-sublime-merge.sh
@@ -29,6 +29,18 @@ if ! [ -f "$BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH" ]; then
   return 1
 fi
 
+read current_theme_name < "$BASE16_SHELL_THEME_NAME_PATH"
+
+# The Sublime Merge theme should exist
+if ! [ -f "$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH/base16-sublime-merge/colorschemes/base16-$current_theme_name.sublime-color-scheme" ]; then
+  output="'$current_theme_name' theme doesn't exist in base16-sublime-merge. Make sure "
+  output+="the local repository is using the latest commit. \`cd\` to "
+  output+="the directory and try doing a \`git pull\`."
+
+  echo $output
+  exit 1
+fi
+
 find_replace_json_value_in_sublimemerge_settings() {
   local property=$1
   local value=$2
@@ -41,7 +53,5 @@ find_replace_json_value_in_sublimemerge_settings() {
 # ----------------------------------------------------------------------
 # Execution
 # ----------------------------------------------------------------------
-read current_theme_name < "$BASE16_SHELL_THEME_NAME_PATH"
-
 find_replace_json_value_in_sublimemerge_settings "theme" "base16-$current_theme_name.sublime-theme"
 find_replace_json_value_in_sublimemerge_settings "color_scheme" "base16-$current_theme_name.sublime-color-scheme"

--- a/hooks/base16-vim.sh
+++ b/hooks/base16-vim.sh
@@ -20,14 +20,15 @@ fi
 # ----------------------------------------------------------------------
 read current_theme_name < "$BASE16_SHELL_THEME_NAME_PATH"
 
-vim_output="if !exists('g:colors_name') || g:colors_name != 'base16-$current_theme_name'\n"
-vim_output+="  colorscheme base16-$current_theme_name\n"
-vim_output+="endif"
+cat > "$BASE16_SHELL_VIM_PATH" << EOF
+if !exists('g:colors_name') || g:colors_name != 'base16-$current_theme_name'
+  colorscheme base16-$current_theme_name
+endif
+EOF
 
-nvim_output="local current_theme_name = \"$current_theme_name\"\n"
-nvim_output+="if current_theme_name ~= \"\" and vim.g.colors_name ~= 'base16-' .. current_theme_name then\n"
-nvim_output+="  vim.cmd('colorscheme base16-' .. current_theme_name)\n"
-nvim_output+="end"
-
-echo -e "$vim_output" >| "$BASE16_SHELL_VIM_PATH"
-echo -e "$nvim_output" >| "$BASE16_SHELL_NVIM_PATH"
+cat > "$BASE16_SHELL_NVIM_PATH" << EOF
+local current_theme_name = "$current_theme_name"
+if current_theme_name ~= "" and vim.g.colors_name ~= 'base16-' .. current_theme_name then
+  vim.cmd('colorscheme base16-' .. current_theme_name)
+end
+EOF

--- a/hooks/base16-vim.sh
+++ b/hooks/base16-vim.sh
@@ -21,14 +21,28 @@ fi
 read current_theme_name < "$BASE16_SHELL_THEME_NAME_PATH"
 
 cat > "$BASE16_SHELL_VIM_PATH" << EOF
-if !exists('g:colors_name') || g:colors_name != 'base16-$current_theme_name'
+function! ColorschemeExists(theme)
+    try
+        execute 'colorscheme ' . a:theme
+        return 1
+    catch
+        return 0
+    endtry
+endfunction
+
+if strlen('$current_theme_name') > 0 && (!exists('g:colors_name') || g:colors_name != 'base16-$current_theme_name') && ColorschemeExists('base16-$current_theme_name')
   colorscheme base16-$current_theme_name
 endif
 EOF
 
 cat > "$BASE16_SHELL_NVIM_PATH" << EOF
 local current_theme_name = "$current_theme_name"
-if current_theme_name ~= "" and vim.g.colors_name ~= 'base16-' .. current_theme_name then
+function colorscheme_exists(scheme)
+    local status_ok, _ = pcall(vim.cmd, "colorscheme " .. scheme)
+    return status_ok
+end
+
+if current_theme_name and current_theme_name ~= "" and vim.g.colors_name ~= 'base16-' .. current_theme_name and colorscheme_exists('base16-' .. current_theme_name) then
   vim.cmd('colorscheme base16-' .. current_theme_name)
 end
 EOF


### PR DESCRIPTION
This is already currently done on the other hooks, so only added to vim and sublime-merge hook.

The issue this fixes could arise when a theme like `ocean` exists in base16-shell, but doesn't exist for base16-vim or base16-sublime-merge because the user hasn't pulled those repos yet.