### PR TITLE
Add sublime-merge hook support for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,28 @@ Include `delta.gitconfig` in your Git config file i.e. `~/.gitconfig`:
 `path/to/sublimemerge/Packages/base16-sublime-merge`.
 
 The Sublime Merge package path must be added to your shell `.*rc` file.
-You find find this value by opening `Sublime Merge -> Preferences ->
-Browse Packages...`. Add this directory path to your shell `.*rc` file:
+You find find this value in Linux by opening `Sublime Merge ->
+Preferences -> Browse Packages...` or on MacOS with `Sublime Merge ->
+Settings... -> Browse Packages...`. Add this directory path to your
+shell `.*rc` file:
 
 ```shell
 export BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH="path/to/sublime-merge/Packages"
 ```
+
+Make sure
+`$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH/User/Preferences.sublime-settings`
+exists and contains the `theme` and `color_scheme` json properties. If
+they don't exist, make sure the file contains them:
+
+```json
+{
+    "theme": "Merge Dark.sublime-theme",
+    "color_scheme": "Merge Dark.sublime-color-scheme"
+}
+```
+This is necessary because the hook finds those properties and replaces
+the values.
 
 ### Keeping your themes up to date
 

--- a/hooks/base16-sublime-merge.sh
+++ b/hooks/base16-sublime-merge.sh
@@ -34,8 +34,23 @@ find_replace_json_value_in_sublimemerge_settings() {
   local value=$2
   local json_file="$BASE16_SHELL_SUBLIMEMERGE_PACKAGE_PATH"/User/Preferences.sublime-settings
 
-  # Use sed to find the property and change its value
-  sed -i "s/\"$property\": \".*\"/\"$property\": \"$value\"/" $BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH
+  # Determine the operating system
+  OS="$(uname)"
+
+  # Define the sed command based on the operating system
+  case "$OS" in
+    Darwin|FreeBSD)
+      # macOS system (BSD sed)
+      SED_COMMAND=(sed -i '')
+      ;;
+    *)
+      # Assume Linux or other (GNU sed)
+      SED_COMMAND=(sed -i)
+      ;;
+  esac
+
+  # Use the determined sed command in your script
+  "${SED_COMMAND[@]}" "s/\"$property\": \".*\"/\"$property\": \"$value\"/" "$BASE16_SHELL_SUBLIMEMERGE_SETTINGS_PATH"
 }
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
- `sed` is used in the script and it's not portable between Linux and MacOS so this fixes that
- Add instructions to ensure json properties exist otherwise the hook doesn't find/replace anything