### PR TITLE
Use clobber redirection operator when writing vim scripts

### DIFF
--- a/hooks/base16-vim.sh
+++ b/hooks/base16-vim.sh
@@ -20,7 +20,7 @@ fi
 # ----------------------------------------------------------------------
 read current_theme_name < "$BASE16_SHELL_THEME_NAME_PATH"
 
-cat > "$BASE16_SHELL_VIM_PATH" << EOF
+cat >| "$BASE16_SHELL_VIM_PATH" << EOF
 function! ColorschemeExists(theme)
     try
         execute 'colorscheme ' . a:theme
@@ -35,7 +35,7 @@ if strlen('$current_theme_name') > 0 && (!exists('g:colors_name') || g:colors_na
 endif
 EOF
 
-cat > "$BASE16_SHELL_NVIM_PATH" << EOF
+cat >| "$BASE16_SHELL_NVIM_PATH" << EOF
 local current_theme_name = "$current_theme_name"
 function colorscheme_exists(scheme)
     local status_ok, _ = pcall(vim.cmd, "colorscheme " .. scheme)


### PR DESCRIPTION
It looks like the old behavior before 9ed4181e1b34766f64e38ddee70214ebd324c167 used the `>|` clobber redirection but that commit changed it to the normal `>` redirection operator which relies on the shell's settings to have clobber enabled (which isn't always the case).

The proper way for a hook like this that controls the files in question should just clobber it.