### PR TITLE
template: (base24) escape codes to the tty

### DIFF
--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -30,25 +30,30 @@ color21="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
 color_foreground="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05
 color_background="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00
 
-if [ -n "$TMUX" ] || [ "${TERM%%[-.]*}" = "tmux" ]; then
+
+if [ -z "$TTY" ] && ! TTY=$(tty); then
+  put_template() { true; }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+elif [ -n "$TMUX" ] || [ "${TERM%%[-.]*}" = "tmux" ]; then
   # Tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' "$@"; }
-  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' "$@"; }
-  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' "$@"; }
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' "$@" > "$TTY"; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' "$@" > "$TTY"; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' "$@" > "$TTY"; }
 elif [ "${TERM%%[-.]*}" = "screen" ]; then
   # GNU screen (screen, screen-256color, screen-256color-bce)
-  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' "$@"; }
-  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' "$@"; }
-  put_template_custom() { printf '\033P\033]%s%s\007\033\\' "$@"; }
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' "$@" > "$TTY"; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' "$@" > "$TTY"; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' "$@" > "$TTY"; }
 elif [ "${TERM%%-*}" = "linux" ]; then
-  put_template() { [ "$1" -lt 16 ] && printf "\e]P%x%s" "$1" "$(echo "$2" | sed 's/\///g')"; }
+  put_template() { [ "$1" -lt 16 ] && printf "\e]P%x%s" "$1" "$(echo "$2" | sed 's/\///g')" > "$TTY"; }
   put_template_var() { true; }
   put_template_custom() { true; }
 else
-  put_template() { printf '\033]4;%d;rgb:%s\033\\' "$@"; }
-  put_template_var() { printf '\033]%d;rgb:%s\033\\' "$@"; }
-  put_template_custom() { printf '\033]%s%s\033\\' "$@"; }
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' "$@" > "$TTY"; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' "$@" > "$TTY"; }
+  put_template_custom() { printf '\033]%s%s\033\\' "$@" > "$TTY"; }
 fi
 
 # 16 color space


### PR DESCRIPTION
Currently only the base16 template prints the escape codes to the tty, this allows integrations with tmux/fzf, etc.
This adds the same functionality to the base24 template.