### PR TITLE
Improve `cp` calls & fix a typo

### DIFF
--- a/hooks/base16-hexchat.fish
+++ b/hooks/base16-hexchat.fish
@@ -54,4 +54,4 @@ end
 # Execution
 # ----------------------------------------------------------------------
 
-cp -f "$hexchat_theme_path" "$BASE16_HEXCHAT_COLORS_CONF_PATH"
+command cp -f "$hexchat_theme_path" "$BASE16_HEXCHAT_COLORS_CONF_PATH"

--- a/hooks/base16-hexchat.sh
+++ b/hooks/base16-hexchat.sh
@@ -12,8 +12,7 @@ if [ -z "$BASE16_HEXCHAT_PATH" ]; then
   BASE16_HEXCHAT_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/tinted-theming/base16-hexchat"
 fi
 
-# If BASE16_HEXCHAT_PATH doesn't exist, stop hook
-if [ ! -d "$BASE16_HEXCHAT_PATH" ]; then
+# If BASE16_HEXCHAT_PATH doesn't exist, stop hook if [ ! -d "$BASE16_HEXCHAT_PATH" ]; then
   return 2
 fi
 
@@ -49,4 +48,5 @@ fi
 # Execution
 # ----------------------------------------------------------------------
 
-cp -f "$hexchat_theme_path" "$BASE16_HEXCHAT_COLORS_CONF_PATH"
+command cp -f "$hexchat_theme_path" "$BASE16_HEXCHAT_COLORS_CONF_PATH"
+

--- a/hooks/tinted-jqp.sh
+++ b/hooks/tinted-jqp.sh
@@ -10,7 +10,7 @@
 
 TINTED_JQP_PATH="${TINTED_JQP_PATH:-$BASE16_CONFIG_PATH/tinted-jqp}"
 
-# If TINTED_HEXCHAT_PATH doesn't exist, stop hook
+# If TINTED_JQP_PATH doesn't exist, stop hook
 if [ ! -d "$TINTED_JQP_PATH" ]; then
   return 2
 fi
@@ -20,10 +20,6 @@ TINTED_JQP_CONFIG_FILE="${TINTED_JQP_CONFIG_FILE:-$BASE16_CONFIG_PATH/jqp_theme.
 if [[ -d "$TINTED_JQP_CONFIG_FILE" ]]; then
   2>&1 echo "${TINTED_JQP_CONFIG_FILE} exists but is a directory. It should either be non-existent, or a file."
   return 1
-fi
-
-if [ ! -e "$TINTED_JQP_CONFIG_FILE" ]; then
-  touch "$TINTED_JQP_CONFIG_FILE"
 fi
 
 # Set current theme name


### PR DESCRIPTION
On macOS, the `cp -f` flag does not actually prevent it from asking for confirmation. In my case, I have `cp` aliased to `nocorrect cp -i`, inducing the prompt. Changing the invocation to `command cp -f ...` forces the shell to use the program instead of any alias that shadow `cp`.