### PR TITLE
Match base16 styling spec for base03.

### DIFF
--- a/colortest
+++ b/colortest
@@ -19,7 +19,7 @@ else
 fi
 
 case "$theme_name" in
-  "base16"*) 
+  "base16"*)
     color_variables="\
       base00 \
       base08 \
@@ -43,7 +43,7 @@ case "$theme_name" in
       base02 \
       base04 \
       base06";;
-  "base24"*) 
+  "base24"*)
     color_variables="\
       base00 \
       base08 \
@@ -52,8 +52,8 @@ case "$theme_name" in
       base0D \
       base0E \
       base0C \
-      base06 \
-      base02 \
+      base05 \
+      base03 \
       base12 \
       base14 \
       base13 \
@@ -94,15 +94,15 @@ while [ $i -lt 22 ]; do
   color_variable="color$(printf "%02d" $i)"
   eval current_color=\$$color_variable
   current_color=$(printf "%s" "$current_color" | tr 'a-f' 'A-F' | tr -d '/') # POSIX-compliant uppercase & remove slashes
-  
+
   # Fetching the color name and ANSI label based on position
   base16_color_name=$(printf "%s\n" $color_variables | sed -n "$((i + 1))p")
   ansi_label=$(printf "%s\n" $ansi_labels | sed -n "$((i + 1))p")
-  
+
   # Displaying the color block
   block=$(printf "\033[48;5;%dm___________________________" $i)
   foreground=$(printf "\033[38;5;%dm%s" $i "$color_variable")
   printf "%s %s %s %-30s %s\033[0m\n" "$foreground" "$base16_color_name" "${current_color:-space}" "${ansi_label:-""}" "$block"
-  
+
   i=$((i + 1))
 done

--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # tinted-shell (https://github.com/tinted-theming/tinted-shell)
-# Scheme name: {{scheme-name}} 
+# Scheme name: {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
 export BASE16_THEME={{scheme-slug}}
@@ -13,7 +13,7 @@ color04="{{base0D-hex-r}}/{{base0D-hex-g}}/{{base0D-hex-b}}" # Base 0D - Blue
 color05="{{base0E-hex-r}}/{{base0E-hex-g}}/{{base0E-hex-b}}" # Base 0E - Magenta
 color06="{{base0C-hex-r}}/{{base0C-hex-g}}/{{base0C-hex-b}}" # Base 0C - Cyan
 color07="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05 - White
-color08="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 03 - Bright Black
+color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
 color09="$color01" # Base 08 - Bright Red
 color10="$color02" # Base 0B - Bright Green
 color11="$color03" # Base 0A - Bright Yellow

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # tinted-shell (https://github.com/tinted-theming/tinted-shell)
-# Scheme name: {{scheme-name}} 
+# Scheme name: {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
 export BASE24_THEME="{{scheme-slug}}"
@@ -12,8 +12,8 @@ color03="{{base0A-hex-r}}/{{base0A-hex-g}}/{{base0A-hex-b}}" # Base 0A - Yellow
 color04="{{base0D-hex-r}}/{{base0D-hex-g}}/{{base0D-hex-b}}" # Base 0D - Blue
 color05="{{base0E-hex-r}}/{{base0E-hex-g}}/{{base0E-hex-b}}" # Base 0E - Magenta
 color06="{{base0C-hex-r}}/{{base0C-hex-g}}/{{base0C-hex-b}}" # Base 0C - Cyan
-color07="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06 - White
-color08="{{base02-hex-r}}/{{base02-hex-g}}/{{base02-hex-b}}" # Base 02 - Bright Black
+color07="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05 - White
+color08="{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
 color09="{{base12-hex-r}}/{{base12-hex-g}}/{{base12-hex-b}}" # Base 12 - Bright Red
 color10="{{base14-hex-r}}/{{base14-hex-g}}/{{base14-hex-b}}" # Base 14 - Bright Green
 color11="{{base13-hex-r}}/{{base13-hex-g}}/{{base13-hex-b}}" # Base 13 - Bright Yellow


### PR DESCRIPTION
Base16 styling spec defines base03,ansi 8,bright black.

This is also what base16-shell themes historically expect as this reverts f08cea2f.

It is confusing because base24 uses base02 as color08 (although the styling spec is ambigous, base02 is defined as bright black, but base03 in spec says ansi 8), and some of the themes I checked that exist in both 16&24 have mapped base16 03 to base24 02.
