### PR TITLE
fix(templates): don't write control codes without TTY write permission

### DIFF
--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -30,7 +30,7 @@ color21="{{base06-hex-r}}/{{base06-hex-g}}/{{base06-hex-b}}" # Base 06
 color_foreground="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05
 color_background="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00
 
-if [ -z "$TTY" ] && ! TTY=$(tty); then
+if [ -z "$TTY" ] && ! TTY=$(tty) || [ ! -w "$TTY" ]; then
   put_template() { true; }
   put_template_var() { true; }
   put_template_custom() { true; }

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -31,7 +31,7 @@ color_foreground="{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05
 color_background="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00
 
 
-if [ -z "$TTY" ] && ! TTY=$(tty); then
+if [ -z "$TTY" ] && ! TTY=$(tty) || [ ! -w "$TTY" ]; then
   put_template() { true; }
   put_template_var() { true; }
   put_template_custom() { true; }


### PR DESCRIPTION
This fix is due to the user may not have permission writing to the TTY. For example, when you `su - new_user`, the TTY is created by the origin_user. Therefore, the new_user won't have the permission writing to the TTY. A warning will popup when you change to a new_user who has installed the tinted-shell.